### PR TITLE
Update repo url

### DIFF
--- a/install-opencv.sh
+++ b/install-opencv.sh
@@ -36,7 +36,7 @@ sudo apt-get install -y doxygen
 # INSTALL THE LIBRARY (YOU CAN CHANGE '3.1.0' FOR THE LAST STABLE VERSION)
 
 sudo apt-get install -y unzip wget
-wget https://github.com/Itseez/opencv/archive/3.1.0.zip
+wget https://github.com/opencv/opencv/archive/3.1.0.zip
 unzip 3.1.0.zip
 rm 3.1.0.zip
 mv opencv-3.1.0 OpenCV


### PR DESCRIPTION
They have moved the OpenCV repo from Itseez to OpenCV organization. The old url is still working, but I think it is more convenient to use the new one (just in case it stop working one day).
