### PR TITLE
incomplete deps

### DIFF
--- a/scripts/bash/install-opencv.sh
+++ b/scripts/bash/install-opencv.sh
@@ -44,6 +44,8 @@ sudo apt-get install -y ant default-jdk
 # Documentation:
 sudo apt-get install -y doxygen
 
+# Lapacke
+sudo apt-get install -y liblapacke-dev checkinstall
 
 # 3. INSTALL THE LIBRARY (YOU CAN CHANGE '3.2.0' FOR THE LAST STABLE VERSION)
 


### PR DESCRIPTION
The installation fails without these packages installed.

Corresponding bug: http://answers.opencv.org/question/121651/fata-error-lapacke_h_path-notfound-when-building-opencv-32/