### PR TITLE
Fixed installation bug

### DIFF
--- a/scripts/bash/install-opencv.sh
+++ b/scripts/bash/install-opencv.sh
@@ -61,7 +61,7 @@ wget https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip
 unzip ${OPENCV_VERSION}.zip
 rm ${OPENCV_VERSION}.zip
 mv opencv-${OPENCV_VERSION} OpenCV
-cd OpenCV
+cd OpenCV/opencv-${OPENCV_VERSION}
 mkdir build
 cd build
 cmake -DWITH_QT=ON -DWITH_OPENGL=ON -DFORCE_VTK=ON -DWITH_TBB=ON -DWITH_GDAL=ON -DWITH_XINE=ON -DBUILD_EXAMPLES=ON -DENABLE_PRECOMPILED_HEADERS=OFF ..


### PR DESCRIPTION
On line 64, the script goes into the OpenCV directory when it should instead go to the OpenCV/opencv-${OPENCV_VERSION} directory. Otherwise, cmake fails.